### PR TITLE
Fix crash when exporting meshes (hack)

### DIFF
--- a/gltf_document.cpp
+++ b/gltf_document.cpp
@@ -2444,6 +2444,9 @@ Error GLTFDocument::_serialize_meshes(GLTFState &state) {
 					{
 						for (int k = 0; k < vs; k += 3) {
 							generated_indices.write[k] = k;
+							if (k + 2 >= generated_indices.size()) {
+								generated_indices.resize(k + 2 + 1);
+							}
 							generated_indices.write[k + 1] = k + 2;
 							generated_indices.write[k + 2] = k + 1;
 						}


### PR DESCRIPTION
Probably not the best way to do this... not sure why it happens

This happened only 2 times during the export of my scene.

1) vs was 9781 and k was 9780
2) vs was 7863 and k was 7865