### PR TITLE
Fix uninitialized memory due to blend shapes with no default weights.

### DIFF
--- a/gltf_document.cpp
+++ b/gltf_document.cpp
@@ -2884,6 +2884,12 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 			for (int j = 0; j < weights.size(); j++) {
 				mesh->blend_weights.write[j] = weights[j];
 			}
+		} else {
+			// CowData.resize() does not default initialize trivial objects.
+			// Avoid initialized blendshapes:
+			for (int j = 0; j < mesh->blend_weights.size(); j++) {
+				mesh->blend_weights.write[j] = 0.0f;
+			}
 		}
 
 		state->meshes.push_back(mesh);


### PR DESCRIPTION
The code uses Vector.resize, and then subsequently fills in weights specified in ["weights"] in the glTF document, if they exist.

However, Vector.resize calls CowData.resize, which does not construct (zero-initialize) types with __has_trivial_constructor(). This leaves primitives like float or byte etc. uninitialized.

Hence, if the "weights" do not exist in the glTF document, we must zero-initialize all weights.